### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP server that provides tools to interact with the Farcaster network ([farcaster.xyz](https://www.farcaster.xyz)), allowing AI models to fetch casts, search channels, and analyze content.
 
+<a href="https://glama.ai/mcp/servers/koo5epnlc7">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/koo5epnlc7/badge" alt="Farcaster Server MCP server" />
+</a>
+
 ## Features
 
 - **Get User Casts**: Retrieve casts from a specific Farcaster user by FID
@@ -127,4 +131,4 @@ npm run dev
 
 ## License
 
-MIT 
+MIT


### PR DESCRIPTION
This PR adds a badge for the [Farcaster MCP Server](https://glama.ai/mcp/servers/koo5epnlc7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/koo5epnlc7">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/koo5epnlc7/badge" alt="Farcaster Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.